### PR TITLE
[BUGFIX] Missing check on non-null intermediate airport

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,9 +47,9 @@ jobs:
 
   # Comment coverage in the Pull Request after generating badges
   coverage:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     needs: build-test
-
     steps:
       - name: Download JaCoCo report
         uses: actions/download-artifact@v4

--- a/src/main/java/com/ryanair/interconnector/service/impl/InterconnectionServiceImpl.java
+++ b/src/main/java/com/ryanair/interconnector/service/impl/InterconnectionServiceImpl.java
@@ -6,7 +6,7 @@ import com.ryanair.interconnector.mapping.ConnectionMapper;
 import com.ryanair.interconnector.service.InterconnectionService;
 import com.ryanair.interconnector.service.RouteQueryService;
 import com.ryanair.interconnector.service.ScheduleQueryService;
-import com.ryanair.interconnector.validation.FlightConnectionValidator;
+import com.ryanair.interconnector.validation.connection.FlightConnectionValidator;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/ryanair/interconnector/validation/connection/FlightConnectionValidator.java
+++ b/src/main/java/com/ryanair/interconnector/validation/connection/FlightConnectionValidator.java
@@ -1,10 +1,10 @@
-package com.ryanair.interconnector.validation;
+package com.ryanair.interconnector.validation.connection;
 
 import com.ryanair.interconnector.dto.FlightSlot;
 
 /**
  * Interface for validating flight connections.
- * This interface defines a method to check if a connection between two flight slots is valid depending on specific criteria.
+ * It defines a method to check if a connection between two flight slots is valid depending on specific criteria.
  */
 public interface FlightConnectionValidator {
 

--- a/src/main/java/com/ryanair/interconnector/validation/connection/MinimumLayoverValidator.java
+++ b/src/main/java/com/ryanair/interconnector/validation/connection/MinimumLayoverValidator.java
@@ -1,4 +1,4 @@
-package com.ryanair.interconnector.validation;
+package com.ryanair.interconnector.validation.connection;
 
 import com.ryanair.interconnector.dto.FlightSlot;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/ryanair/interconnector/validation/route/NullConnectingAirportValidator.java
+++ b/src/main/java/com/ryanair/interconnector/validation/route/NullConnectingAirportValidator.java
@@ -1,0 +1,15 @@
+package com.ryanair.interconnector.validation.route;
+
+import com.ryanair.interconnectingflights.external.model.Route;
+import org.springframework.stereotype.Component;
+
+/**
+ * Validates that the connecting airport in a route is null.
+ */
+@Component
+public class NullConnectingAirportValidator implements RouteValidator {
+  @Override
+  public boolean isValidRoute(Route route) {
+    return route.getConnectingAirport() == null;
+  }
+}

--- a/src/main/java/com/ryanair/interconnector/validation/route/RouteOperatorValidator.java
+++ b/src/main/java/com/ryanair/interconnector/validation/route/RouteOperatorValidator.java
@@ -1,0 +1,18 @@
+package com.ryanair.interconnector.validation.route;
+
+import com.ryanair.interconnectingflights.external.model.Route;
+import org.springframework.stereotype.Component;
+
+/**
+ * Validates that the route is operated by Ryanair.
+ */
+@Component
+public class RouteOperatorValidator  implements  RouteValidator {
+
+  private static final String OPERATOR = "RYANAIR";
+
+  @Override
+  public boolean isValidRoute(Route route) {
+    return OPERATOR.equals(route.getOperator());
+  }
+}

--- a/src/main/java/com/ryanair/interconnector/validation/route/RouteValidator.java
+++ b/src/main/java/com/ryanair/interconnector/validation/route/RouteValidator.java
@@ -1,0 +1,13 @@
+package com.ryanair.interconnector.validation.route;
+
+import com.ryanair.interconnectingflights.external.model.Route;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Interface for validating a Route depending on different criteria.
+ *
+ */
+public interface RouteValidator {
+
+  boolean isValidRoute(@NotNull Route route);
+}

--- a/src/main/resources/openapi/clients/client-routes-api.yaml
+++ b/src/main/resources/openapi/clients/client-routes-api.yaml
@@ -29,7 +29,6 @@ components:
           type: string
         connectingAirport:
           type: string
-          nullable: true
         newRoute:
           type: boolean
         seasonalRoute:

--- a/src/test/java/com/ryanair/interconnector/service/impl/InterconnectionServiceImplTest.java
+++ b/src/test/java/com/ryanair/interconnector/service/impl/InterconnectionServiceImplTest.java
@@ -15,7 +15,7 @@ import com.ryanair.interconnector.dto.FlightSlot;
 import com.ryanair.interconnector.mapping.ConnectionMapper;
 import com.ryanair.interconnector.service.RouteQueryService;
 import com.ryanair.interconnector.service.ScheduleQueryService;
-import com.ryanair.interconnector.validation.FlightConnectionValidator;
+import com.ryanair.interconnector.validation.connection.FlightConnectionValidator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/ryanair/interconnector/service/impl/RouteQueryServiceImplTest.java
+++ b/src/test/java/com/ryanair/interconnector/service/impl/RouteQueryServiceImplTest.java
@@ -3,11 +3,15 @@ package com.ryanair.interconnector.service.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import com.ryanair.interconnectingflights.external.model.Route;
 import com.ryanair.interconnector.client.CachedRoutesProvider;
 import com.ryanair.interconnector.testutils.DirectExecutor;
+import com.ryanair.interconnector.validation.route.RouteValidator;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,6 +22,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -28,8 +33,7 @@ import java.util.stream.Stream;
 @ExtendWith(MockitoExtension.class)
 class RouteQueryServiceImplTest {
 
-  private static final String VALID_OPERATOR = "RYANAIR";
-  private static final String INVALID_OPERATOR = "INVALID";
+  private static final String OPERATOR = "RYANAIR";
 
   private static final String ORIGIN_AIRPORT = "DUB";
   private static final String DESTINATION_AIRPORT = "STN";
@@ -42,16 +46,28 @@ class RouteQueryServiceImplTest {
   // Using direct execution for the unit tests, as we do not want async checks here
   @Spy
   Executor directExecutor = new DirectExecutor();
+  @Mock
+  RouteValidator routeValidator;
+  @Spy
+  List<RouteValidator> validatorList = new ArrayList<>();
 
   @InjectMocks
   RouteQueryServiceImpl service;
 
   private final Route validRoute = new Route().airportFrom(ORIGIN_AIRPORT).airportTo(DESTINATION_AIRPORT).operator(
-      VALID_OPERATOR);
-  private final Route invalidRoute = new Route().airportFrom(ORIGIN_AIRPORT).airportTo(DESTINATION_AIRPORT).operator(INVALID_OPERATOR);
+      OPERATOR);
+
+  private final Route invalidRoute = new Route().airportFrom(ORIGIN_AIRPORT).airportTo(DESTINATION_AIRPORT).operator(
+      "INVALID_OPERATOR");
 
   @Nested
   class ExistsValidRoute {
+
+    @BeforeEach
+    void setUp() {
+      validatorList.clear();
+      validatorList.add(routeValidator);
+    }
 
     @ParameterizedTest
     @CsvSource({
@@ -63,7 +79,9 @@ class RouteQueryServiceImplTest {
     void shouldReturnTrueWhenValidRouteExists(String originAirport, String destinationAirport)
         throws ExecutionException, InterruptedException {
       // Arrange
-      when(routesProvider.fetchAllRoutesCached()).thenReturn(List.of(validRoute, invalidRoute));
+      when(routesProvider.fetchAllRoutesCached()).thenReturn(List.of(invalidRoute, validRoute));
+      when(routeValidator.isValidRoute(validRoute)).thenReturn(true);
+      lenient().when(routeValidator.isValidRoute(invalidRoute)).thenReturn(false);
 
       // Act
       CompletableFuture<Boolean> result = service.existsDirectRoute(originAirport, destinationAirport);
@@ -74,9 +92,10 @@ class RouteQueryServiceImplTest {
 
 
     @Test
-    void shouldReturnFalseIfNoMatchingRouteExistsWithValidOperator() throws ExecutionException, InterruptedException {
+    void shouldReturnFalseIfNoMatchingRouteIsValid() throws ExecutionException, InterruptedException {
       // Arrange
       when(routesProvider.fetchAllRoutesCached()).thenReturn(List.of(invalidRoute));
+      when(routeValidator.isValidRoute(invalidRoute)).thenReturn(false);
 
       // Act
       CompletableFuture<Boolean> result = service.existsDirectRoute(ORIGIN_AIRPORT, DESTINATION_AIRPORT);
@@ -100,8 +119,8 @@ class RouteQueryServiceImplTest {
     @Test
     void shouldReturnFalseIfAllRoutesAreDifferent() throws ExecutionException, InterruptedException {
       // Arrange
-      Route differentRoute = new Route().airportFrom(ORIGIN_AIRPORT).airportTo("ABC").operator(VALID_OPERATOR);
-      Route anotherDifferentRoute = new Route().airportFrom("LMN").airportTo(DESTINATION_AIRPORT).operator(VALID_OPERATOR);
+      Route differentRoute = new Route().airportFrom(ORIGIN_AIRPORT).airportTo("ABC").operator(OPERATOR);
+      Route anotherDifferentRoute = new Route().airportFrom("LMN").airportTo(DESTINATION_AIRPORT).operator(OPERATOR);
       when(routesProvider.fetchAllRoutesCached()).thenReturn(List.of(differentRoute, anotherDifferentRoute));
 
       // Act
@@ -119,15 +138,20 @@ class RouteQueryServiceImplTest {
     private static final String INTERMEDIATE_AIRPORT_2 = "BGY";
 
     private static final Route FROM_ROUTE_1 = new Route().airportFrom(ORIGIN_AIRPORT).airportTo(INTERMEDIATE_AIRPORT_1).operator(
-        VALID_OPERATOR);
+        OPERATOR);
     private static final Route FROM_ROUTE_2 = new Route().airportFrom(ORIGIN_AIRPORT).airportTo(INTERMEDIATE_AIRPORT_2).operator(
-        VALID_OPERATOR);
+        OPERATOR);
     private static final Route TO_ROUTE_1 = new Route().airportFrom(INTERMEDIATE_AIRPORT_1).airportTo(DESTINATION_AIRPORT).operator(
-        VALID_OPERATOR);
+        OPERATOR);
     private static final Route TO_ROUTE_2 = new Route().airportFrom(INTERMEDIATE_AIRPORT_2).airportTo(DESTINATION_AIRPORT).operator(
-        VALID_OPERATOR);
+        OPERATOR);
 
 
+    @BeforeEach
+    void setUp() {
+      validatorList.clear();
+      validatorList.add(routeValidator);
+    }
 
     /**
      * Provides various permutations of [FROM_ROUTE_1, FROM_ROUTE_2, TO_ROUTE_1, TO_ROUTE_2] to ensure the method works
@@ -149,6 +173,7 @@ class RouteQueryServiceImplTest {
       // Arrange
       when(routesProvider.fetchAllRoutesCached())
           .thenReturn(routesInAnyOrder);
+      when(routeValidator.isValidRoute(any())).thenReturn(true);
 
       Set<String> expected = Set.of(INTERMEDIATE_AIRPORT_1, INTERMEDIATE_AIRPORT_2);
 
@@ -165,6 +190,7 @@ class RouteQueryServiceImplTest {
       // Arrange
       when(routesProvider.fetchAllRoutesCached())
           .thenReturn(List.of(FROM_ROUTE_1, TO_ROUTE_1));
+      when(routeValidator.isValidRoute(any())).thenReturn(true);
 
       // Act
       CompletableFuture<Set<String>> result = service.intermediateAirports(ORIGIN_AIRPORT_LOWER, DESTINATION_AIRPORT_LOWER);
@@ -180,6 +206,7 @@ class RouteQueryServiceImplTest {
       // Arrange
       when(routesProvider.fetchAllRoutesCached())
           .thenReturn(List.of(FROM_ROUTE_1, TO_ROUTE_2));
+      when(routeValidator.isValidRoute(any())).thenReturn(true);
 
       // Act
       CompletableFuture<Set<String>> result = service.intermediateAirports(ORIGIN_AIRPORT, DESTINATION_AIRPORT);
@@ -190,18 +217,19 @@ class RouteQueryServiceImplTest {
     }
 
     @ParameterizedTest
-    @CsvSource(
-        value = {
-            VALID_OPERATOR + ", " + INVALID_OPERATOR,
-            INVALID_OPERATOR + ", " + VALID_OPERATOR,
-            INVALID_OPERATOR + ", " + INVALID_OPERATOR
-        }
-    )
-    void shouldIgnoresInvalidOperatorRoutes(String operatorFirstFlight, String operatorSecondFlight)
+    @CsvSource({
+        "false, false",
+        "true, false",
+        "false, true"
+    })
+    void shouldIgnoresInvalidRoutes(boolean firstValid, boolean secondValid)
         throws ExecutionException, InterruptedException {
       // Arrange
-      Route wrongOperator1 = new Route().airportFrom(ORIGIN_AIRPORT).airportTo(INTERMEDIATE_AIRPORT_1).operator(operatorFirstFlight);
-      Route wrongOperator2 = new Route().airportFrom(INTERMEDIATE_AIRPORT_1).airportTo(DESTINATION_AIRPORT).operator(operatorSecondFlight);
+      Route wrongOperator1 = new Route().airportFrom(ORIGIN_AIRPORT).airportTo(INTERMEDIATE_AIRPORT_1).operator(OPERATOR);
+      Route wrongOperator2 = new Route().airportFrom(INTERMEDIATE_AIRPORT_1).airportTo(DESTINATION_AIRPORT).operator(OPERATOR);
+
+      when(routeValidator.isValidRoute(wrongOperator1)).thenReturn(firstValid);
+      when(routeValidator.isValidRoute(wrongOperator2)).thenReturn(secondValid);
 
       when(routesProvider.fetchAllRoutesCached()).thenReturn(List.of(wrongOperator1, wrongOperator2));
 

--- a/src/test/java/com/ryanair/interconnector/validation/connection/MinimumLayoverValidatorTest.java
+++ b/src/test/java/com/ryanair/interconnector/validation/connection/MinimumLayoverValidatorTest.java
@@ -1,4 +1,4 @@
-package com.ryanair.interconnector.validation;
+package com.ryanair.interconnector.validation.connection;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/src/test/java/com/ryanair/interconnector/validation/route/NullConnectingAirportValidatorTest.java
+++ b/src/test/java/com/ryanair/interconnector/validation/route/NullConnectingAirportValidatorTest.java
@@ -1,0 +1,38 @@
+package com.ryanair.interconnector.validation.route;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.ryanair.interconnectingflights.external.model.Route;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class NullConnectingAirportValidatorTest {
+
+  RouteValidator routeValidator = new NullConnectingAirportValidator();
+
+  @Test
+  void testValidRoute() {
+    // Arrange
+    Route route = new Route();
+    route.setConnectingAirport(null);
+
+    // Act & Assert
+    assertTrue(routeValidator.isValidRoute(route));
+  }
+
+  @ParameterizedTest
+  @EmptySource
+  @ValueSource(strings = { "DUB", "DUUUB", "  " })
+  void testInvalidRoute(String nonNullConnectingAirport) {
+    // Arrange
+    Route route = new Route();
+    route.setConnectingAirport(nonNullConnectingAirport);
+
+    // Act & Assert
+    assertFalse(routeValidator.isValidRoute(route));
+  }
+
+}

--- a/src/test/java/com/ryanair/interconnector/validation/route/RouteOperatorValidatorTest.java
+++ b/src/test/java/com/ryanair/interconnector/validation/route/RouteOperatorValidatorTest.java
@@ -1,0 +1,33 @@
+package com.ryanair.interconnector.validation.route;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.ryanair.interconnectingflights.external.model.Route;
+import org.junit.jupiter.api.Test;
+
+class RouteOperatorValidatorTest {
+
+  RouteValidator routeValidator = new RouteOperatorValidator();
+
+  @Test
+  void testIsValidRoute() {
+    //Arrange
+    Route validRoute = new Route();
+    validRoute.setOperator("RYANAIR");
+
+    // Act & Assert
+    assertTrue(routeValidator.isValidRoute(validRoute));
+  }
+
+  @Test
+  void testIsInvalidRoute() {
+    // Arrange
+    Route invalidRoute = new Route();
+    invalidRoute.setOperator("OTHER_AIRLINE");
+
+    // Act & Assert
+    assertFalse(routeValidator.isValidRoute(invalidRoute));
+  }
+
+}

--- a/src/test/resources/wiremock/__files/routes/routes-response.json
+++ b/src/test/resources/wiremock/__files/routes/routes-response.json
@@ -34,5 +34,14 @@
     "seasonalRoute": false,
     "operator": "OTHER",
     "group": "ETHNIC"
+  },
+  {
+    "airportFrom": "ALC",
+    "airportTo": "MRS",
+    "connectingAirport": "DUB",
+    "newRoute": false,
+    "seasonalRoute": false,
+    "operator": "RYANAIR",
+    "group": "ETHNIC"
   }
 ]


### PR DESCRIPTION
## Summary

During the code, one of the requirements of the task was missed (ensuring that connections to airport have null values)
The objective of this change is to fix that missing requirement and adapt the structure of the code for the route validation strategies.

## Detailed changes

- Created validators for the routes following a composite/strategy pattern
- Created two validators, one for the operator check and the other for the null check
- Added and modified tests to adapt to this new structure (unit + integration)